### PR TITLE
Ejemplo de charla en speakers.yml

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -4,8 +4,8 @@
   title: cfp.level.basic
   schedule:
     - time:        "10:00 - 10:50"
-      title:       introduction.title
-      description: introduction.description
+      title:       Intro a BDD
+      description: En esta charla se va a hacer una introducción a un proceso de desarrollo de aplicaciones basado en el comportamiento, sus diferencias con técnicas más conocidas como el TDD y como podemos utilizar herramientas como phpspec y Behat para automatizar nuestro tests.
       speaker:     iambrosi
 
 - room_name: Sala 2


### PR DESCRIPTION
Tanto el título de la charla como la descripción se van a mostrar en español, porque no existe una traducción que coincida con las keys ingresadas en `title` y `description`.

En caso de querer aplicar traducción, el título y la descripción deben agregarse al [archivo de traducciones para charlas](https://github.com/PHPmvd/phpday-website/blob/master/src/App/Resources/translations/talks.es.yml).

Ejemplo

``` yaml
# src/App/Resources/translations/talks.en.yml

bdd:
    title: Intro to BDD
    description: >
        This talk will be an introduction to a development process based on 
        behaviours, its differences with known techniques such as TDD, and 
        how we can use some tools like phpspec and Behat to automate our 
        tests.
```

``` yml
# config/schedule.yml

- room_name: Sala 1
  title: cfp.level.basic
  schedule:
    - time:        "10:00 - 10:50"
      title:       bdd.title
      description: bdd.description
      speaker:     iambrosi
```

**Nota:** el valor de `speaker` es la key del speaker en el archivo [`config/speakers.yml`](https://github.com/PHPmvd/phpday-website/blob/3e2db963bd0445edf886ee596f461a2d0713fd9d/config/speakers.yml).

ping @AV4TAr 
